### PR TITLE
Fix document

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ require 'capistrano/telegram_notification'
 if use webhook
 
 ```ruby
-set :telegram_bot_token, '4223:dfsdaf..'
+set :telegram_bot_key, '4223:dfsdaf..'
 set :telegram_chat_id, '-4234123'
 
 after 'deploy:started', 'telegram:deploy:start'


### PR DESCRIPTION
Docs say telegram_bot_token while code use telegram_bot_key?
Good docs!